### PR TITLE
Improve browser support by adding Browserify versions of createHash and randomBytes as dependencies

### DIFF
--- a/lib/params.js
+++ b/lib/params.js
@@ -1,6 +1,13 @@
 'use strict'
 
+// Get Node support for createHash
 const crypto = require('crypto')
+
+// Get Browser support for createHash
+const browserifyCreateHash = require('create-hash')
+
+// Use the Node version of createHash if available, otherwise use the Browserify version
+const createHash = crypto.createHash ? crypto.createHash : browserifyCreateHash
 
 const SRPInteger = require('./srp-integer')
 
@@ -22,8 +29,8 @@ const input = {
   hashOutputBytes: (256 / 8)
 }
 
-function H (...args) {
-  const h = crypto.createHash('sha256')
+function H(...args) {
+  const h = createHash('sha256')
 
   for (const arg of args) {
     if (arg instanceof SRPInteger) {

--- a/lib/srp-integer.js
+++ b/lib/srp-integer.js
@@ -1,6 +1,14 @@
 'use strict'
 
+// Get Node support for randomBytes
 const crypto = require('crypto')
+
+// Get Browser support for randomBytes
+const browserifyRandomBytes = require('randombytes')
+
+// Use the Node version of randomBytes if available, otherwise use the Browserify version
+const randomBytes = crypto.randomBytes ? crypto.randomBytes : browserifyRandomBytes
+
 const padStart = require('pad-start')
 const { BigInteger } = require('jsbn')
 
@@ -63,7 +71,7 @@ SRPInteger.fromHex = function (input) {
 }
 
 SRPInteger.randomInteger = function () {
-  return SRPInteger.fromHex(crypto.randomBytes(params.hashOutputBytes).toString('hex'))
+  return SRPInteger.fromHex(randomBytes(params.hashOutputBytes).toString('hex'))
 }
 
 SRPInteger.ZERO = new SRPInteger(new BigInteger('0'), null)

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "test": "standard && mocha"
   },
   "dependencies": {
+    "create-hash": "^1.1.3",
     "jsbn": "^1.1.0",
-    "pad-start": "^1.0.2"
+    "pad-start": "^1.0.2",
+    "randombytes": "^2.0.5"
   },
   "devDependencies": {
     "mocha": "^3.5.0",


### PR DESCRIPTION
Adds Browserify versions of the necessary Crypto functions (createHash and randomBytes) as dependencies rather than relying on external build tools to make the Browserify functions available.

The implementation defaults to the Node module when available and falls back to the Browserify functions when required.
