### PR TITLE
💥 Derive public part of ephemeral pair

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -12,5 +12,5 @@ export function generateSalt(): string
 export function derivePrivateKey(salt: string, username: string, password: string): string
 export function deriveVerifier(privateKey: string): string
 export function generateEphemeral(): Ephemeral
-export function deriveSession(clientEphemeral: Ephemeral, serverPublicEphemeral: string, salt: string, username: string, password: string): Session
-export function verifySession(clientEphemeral: Ephemeral, clientSession: Session, proof: string): void
+export function deriveSession(clientSecretEphemeral: string, serverPublicEphemeral: string, salt: string, username: string, password: string): Session
+export function verifySession(clientPublicEphemeral: string, clientSession: Session, proof: string): void

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ const serverEphemeral = srp.generateEphemeral(verifier)
 console.log(serverEphemeral.public)
 //=> DA084F5C...
 
+// Store `serverEphemeral.secret` for later use
 // Send `salt` and `serverEphemeral.public` to the client
 ```
 
@@ -84,7 +85,7 @@ const srp = require('secure-remote-password/client')
 const password = '$uper$ecret'
 
 const privateKey = srp.derivePrivateKey(salt, username, password)
-const clientSession = srp.deriveSession(clientEphemeral, serverPublicEphemeral, salt, username, privateKey)
+const clientSession = srp.deriveSession(clientEphemeral.secret, serverPublicEphemeral, salt, username, privateKey)
 
 console.log(clientSession.key)
 //=> 2A6FF04E...
@@ -100,7 +101,10 @@ console.log(clientSession.proof)
 ```js
 const srp = require('secure-remote-password/server')
 
-const serverSession = srp.deriveSession(serverEphemeral, clientPublicEphemeral, salt, username, verifier, clientSessionProof)
+// Previously stored `serverEphemeral.secret`
+const serverSecretEphemeral = '784D6E83...'
+
+const serverSession = srp.deriveSession(serverSecretEphemeral, clientPublicEphemeral, salt, username, verifier, clientSessionProof)
 
 console.log(serverSession.key)
 //=> 2A6FF04E...
@@ -116,7 +120,7 @@ console.log(serverSession.proof)
 ```js
 const srp = require('secure-remote-password/client')
 
-srp.verifySession(clientEphemeral, clientSession, serverSessionProof)
+srp.verifySession(clientEphemeral.public, clientSession, serverSessionProof)
 
 // All done!
 ```
@@ -145,11 +149,11 @@ Derive a verifier to be stored for subsequent authentication atempts.
 
 Generate ephemeral values used to initiate an authentication session.
 
-#### `Client.deriveSession(clientEphemeral, serverPublicEphemeral, salt, username, privateKey) => { key: string, proof: string }`
+#### `Client.deriveSession(clientSecretEphemeral, serverPublicEphemeral, salt, username, privateKey) => { key: string, proof: string }`
 
 Comptue a session key and proof. The proof is to be sent to the server for verification.
 
-#### `Client.verifySession(clientEphemeral, clientSession, serverSessionProof) => void`
+#### `Client.verifySession(clientPublicEphemeral, clientSession, serverSessionProof) => void`
 
 Verifies the server provided session proof. Throws an error if the session proof is invalid.
 
@@ -163,7 +167,7 @@ const Server = require('secure-remote-password/server')
 
 Generate ephemeral values used to continue an authentication session.
 
-#### `deriveSession(serverEphemeral, clientPublicEphemeral, salt, username, verifier, clientSessionProof)`
+#### `deriveSession(serverSecretEphemeral, clientPublicEphemeral, salt, username, verifier, clientSessionProof)`
 
 Comptue a session key and proof. The proof is to be sent to the client for verification.
 

--- a/server.d.ts
+++ b/server.d.ts
@@ -9,4 +9,4 @@ export interface Session {
 }
 
 export function generateEphemeral(verifier: string): Ephemeral
-export function deriveSession(serverEphemeral: Ephemeral, clientPublicEphemeral: string, salt: string, username: string, verifier: string, clientSessionProof: string): Session
+export function deriveSession(serverSecretEphemeral: string, clientPublicEphemeral: string, salt: string, username: string, verifier: string, clientSessionProof: string): Session

--- a/test.js
+++ b/test.js
@@ -18,10 +18,10 @@ describe('Secure Remote Password', () => {
     const clientEphemeral = client.generateEphemeral()
     const serverEphemeral = server.generateEphemeral(verifier)
 
-    const clientSession = client.deriveSession(clientEphemeral, serverEphemeral.public, salt, username, privateKey)
-    const serverSession = server.deriveSession(serverEphemeral, clientEphemeral.public, salt, username, verifier, clientSession.proof)
+    const clientSession = client.deriveSession(clientEphemeral.secret, serverEphemeral.public, salt, username, privateKey)
+    const serverSession = server.deriveSession(serverEphemeral.secret, clientEphemeral.public, salt, username, verifier, clientSession.proof)
 
-    client.verifySession(clientEphemeral, clientSession, serverSession.proof)
+    client.verifySession(clientEphemeral.public, clientSession, serverSession.proof)
 
     assert.strictEqual(clientSession.key, serverSession.key)
   })


### PR DESCRIPTION
Migration guide:

Several public functions have been modified to take only the secret or public part of the ephemeral pair, instead of taking the entire pair. This allows you to only persist one value instead of two when authenticating a user.

Affected functions:

- Client side
  - `deriveSession` now only takes secret part.
  - `verifySession` now only takes public part.
- Server side
  - `deriveSession` now only takes secret part.

Fixes: #7