### PR TITLE
🐛 Fix parameter names in Typescript definitions

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -12,5 +12,5 @@ export function generateSalt(): string
 export function derivePrivateKey(salt: string, username: string, password: string): string
 export function deriveVerifier(privateKey: string): string
 export function generateEphemeral(): Ephemeral
-export function deriveSession(clientSecretEphemeral: string, serverPublicEphemeral: string, salt: string, username: string, password: string): Session
-export function verifySession(clientPublicEphemeral: string, clientSession: Session, proof: string): void
+export function deriveSession(clientSecretEphemeral: string, serverPublicEphemeral: string, salt: string, username: string, privateKey: string): Session
+export function verifySession(clientPublicEphemeral: string, clientSession: Session, serverSessionProof: string): void


### PR DESCRIPTION
Client-side `deriveSession` function now uses `privateKey`, not `password`.